### PR TITLE
feat: allow exchanging valid requester oidc tokens for github installation tokens

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@types/fs-extra": "^8.0.1",
     "@types/jest": "^29.0.0",
     "@types/joi": "^14.3.4",
+    "@types/jwk-to-pem": "^2.0.1",
     "@types/morgan": "^1.7.37",
     "@types/node": "^16.0.0",
     "@types/passport": "^1.0.0",
@@ -93,6 +94,7 @@
     "webpack-subresource-integrity": "^5.1.0"
   },
   "dependencies": {
+    "@octokit/auth-app": "^4.0.7",
     "@octokit/rest": "^19.0.5",
     "@sentry/node": "^5.10.2",
     "@slack/bolt": "^3.12.1",
@@ -104,7 +106,10 @@
     "express-history-api-fallback": "^2.2.1",
     "express-session": "^1.17.0",
     "joi": "^14.3.1",
+    "jsonwebtoken": "^8.5.1",
+    "jwk-to-pem": "^2.0.5",
     "morgan": "^1.9.1",
+    "openid-client": "^5.1.10",
     "passport": "^0.4.1",
     "passport-github": "^1.1.0",
     "patch-package": "^6.2.0",

--- a/src/client/components/configurators/CircleCIRequesterConfig.tsx
+++ b/src/client/components/configurators/CircleCIRequesterConfig.tsx
@@ -25,7 +25,7 @@ export function CircleCIRequesterConfig(props: Props) {
       <Paragraph marginBottom={4}>
         You can generate an access token in your{' '}
         <a
-          href={`https://circleci.com/gh/${props.project.repoOwner}/${props.project.repoName}/edit#api`}
+          href={`https://app.circleci.com/settings/project/github/${props.project.repoOwner}/${props.project.repoName}/api`}
           target="_blank"
           rel="noreferrer noopener"
         >

--- a/src/client/components/configurators/__tests__/CircleCIRequesterConfig.spec.tsx
+++ b/src/client/components/configurators/__tests__/CircleCIRequesterConfig.spec.tsx
@@ -18,7 +18,9 @@ describe('<CircleCIRequesterConfig />', () => {
     );
     const link = wrapper.find('a');
     expect(link).toHaveLength(1);
-    expect(link.prop('href')).toBe('https://app.circleci.com/settings/project/github/my-owner/my-repo/api');
+    expect(link.prop('href')).toBe(
+      'https://app.circleci.com/settings/project/github/my-owner/my-repo/api',
+    );
   });
 
   it('should provide an empty original access token if the project is not configured for cirlceci', () => {

--- a/src/client/components/configurators/__tests__/CircleCIRequesterConfig.spec.tsx
+++ b/src/client/components/configurators/__tests__/CircleCIRequesterConfig.spec.tsx
@@ -18,7 +18,7 @@ describe('<CircleCIRequesterConfig />', () => {
     );
     const link = wrapper.find('a');
     expect(link).toHaveLength(1);
-    expect(link.prop('href')).toBe('https://circleci.com/gh/my-owner/my-repo/edit#api');
+    expect(link.prop('href')).toBe('https://app.circleci.com/settings/project/github/my-owner/my-repo/api');
   });
 
   it('should provide an empty original access token if the project is not configured for cirlceci', () => {

--- a/src/client/components/configurators/__tests__/__snapshots__/CircleCIRequesterConfig.spec.tsx.snap
+++ b/src/client/components/configurators/__tests__/__snapshots__/CircleCIRequesterConfig.spec.tsx.snap
@@ -32,7 +32,7 @@ exports[`<CircleCIRequesterConfig /> Should render a GenericAccessTokenRequester
     You can generate an access token in your
      
     <a
-      href="https://circleci.com/gh/my-owner/my-repo/edit#api"
+      href="https://app.circleci.com/settings/project/github/my-owner/my-repo/api"
       rel="noreferrer noopener"
       target="_blank"
     >

--- a/src/server/api/project/config.ts
+++ b/src/server/api/project/config.ts
@@ -19,7 +19,7 @@ const a = createA(d);
 
 export async function updateCircleEnvVars(project: Project, accessToken: string) {
   const client = axios.create({
-    baseURL: 'https://circleci.com/api/v2',
+    baseURL: 'https://circleci.com/api/v1.1',
     auth: {
       username: accessToken,
       password: '',
@@ -27,32 +27,28 @@ export async function updateCircleEnvVars(project: Project, accessToken: string)
     validateStatus: () => true,
   });
 
-  const existing = await client.get(`/project/gh/${project.repoOwner}/${project.repoName}/envvar`);
+  const existing = await client.get(`/project/github/${project.repoOwner}/${project.repoName}/envvar`);
   if (existing.status !== 200) return;
 
-  if (existing.data.items.find(item => item.name === 'CFA_SECRET')) {
-    await client.delete(`/project/gh/${project.repoOwner}/${project.repoName}/envvar/CFA_SECRET`);
+  if (existing.data.find(item => item.name === 'CFA_SECRET')) {
+    await client.delete(`/project/github/${project.repoOwner}/${project.repoName}/envvar/CFA_SECRET`);
   }
   await client.post(
-    `/project/gh/${project.repoOwner}/${project.repoName}/envvar`,
+    `/project/github/${project.repoOwner}/${project.repoName}/envvar`,
     {
-      body: {
-        name: 'CFA_SECRET',
-        value: project.secret,
-      },
+      name: 'CFA_SECRET',
+      value: project.secret,
     },
   );
 
-  if (existing.data.items.find(item => item.name === 'CFA_PROJECT_ID')) {
-    await client.delete(`/project/gh/${project.repoOwner}/${project.repoName}/envvar/CFA_PROJECT_ID`);
+  if (existing.data.find(item => item.name === 'CFA_PROJECT_ID')) {
+    await client.delete(`/project/github/${project.repoOwner}/${project.repoName}/envvar/CFA_PROJECT_ID`);
   }
   await client.post(
-    `/project/gh/${project.repoOwner}/${project.repoName}/envvar`,
+    `/project/github/${project.repoOwner}/${project.repoName}/envvar`,
     {
-      body: {
-        name: 'CFA_PROJECT_ID',
-        value: project.id,
-      },
+      name: 'CFA_PROJECT_ID',
+      value: project.id,
     },
   );
 }
@@ -81,7 +77,7 @@ export function configRoutes() {
         if (!project) return;
 
         const response = await axios.get(
-          `https://circleci.com/api/v2/project/gh/${project.repoOwner}/${project.repoName}/checkout-key`,
+          `https://circleci.com/api/v1.1/project/gh/${project.repoOwner}/${project.repoName}/checkout-key`,
           {
             auth: {
               username: req.body.accessToken,

--- a/src/server/api/project/config.ts
+++ b/src/server/api/project/config.ts
@@ -27,30 +27,30 @@ export async function updateCircleEnvVars(project: Project, accessToken: string)
     validateStatus: () => true,
   });
 
-  const existing = await client.get(`/project/github/${project.repoOwner}/${project.repoName}/envvar`);
+  const existing = await client.get(
+    `/project/github/${project.repoOwner}/${project.repoName}/envvar`,
+  );
   if (existing.status !== 200) return;
 
   if (existing.data.find(item => item.name === 'CFA_SECRET')) {
-    await client.delete(`/project/github/${project.repoOwner}/${project.repoName}/envvar/CFA_SECRET`);
+    await client.delete(
+      `/project/github/${project.repoOwner}/${project.repoName}/envvar/CFA_SECRET`,
+    );
   }
-  await client.post(
-    `/project/github/${project.repoOwner}/${project.repoName}/envvar`,
-    {
-      name: 'CFA_SECRET',
-      value: project.secret,
-    },
-  );
+  await client.post(`/project/github/${project.repoOwner}/${project.repoName}/envvar`, {
+    name: 'CFA_SECRET',
+    value: project.secret,
+  });
 
   if (existing.data.find(item => item.name === 'CFA_PROJECT_ID')) {
-    await client.delete(`/project/github/${project.repoOwner}/${project.repoName}/envvar/CFA_PROJECT_ID`);
+    await client.delete(
+      `/project/github/${project.repoOwner}/${project.repoName}/envvar/CFA_PROJECT_ID`,
+    );
   }
-  await client.post(
-    `/project/github/${project.repoOwner}/${project.repoName}/envvar`,
-    {
-      name: 'CFA_PROJECT_ID',
-      value: project.id,
-    },
-  );
+  await client.post(`/project/github/${project.repoOwner}/${project.repoName}/envvar`, {
+    name: 'CFA_PROJECT_ID',
+    value: project.id,
+  });
 }
 
 export function configRoutes() {

--- a/src/server/api/project/config.ts
+++ b/src/server/api/project/config.ts
@@ -17,6 +17,46 @@ import { getProjectFromIdAndCheckPermissions } from './_safe';
 const d = debug('cfa:server:api:project:config');
 const a = createA(d);
 
+export async function updateCircleEnvVars(project: Project, accessToken: string) {
+  const client = axios.create({
+    baseURL: 'https://circleci.com/api/v2',
+    auth: {
+      username: accessToken,
+      password: '',
+    },
+    validateStatus: () => true,
+  });
+
+  const existing = await client.get(`/project/gh/${project.repoOwner}/${project.repoName}/envvar`);
+  if (existing.status !== 200) return;
+
+  if (existing.data.items.find(item => item.name === 'CFA_SECRET')) {
+    await client.delete(`/project/gh/${project.repoOwner}/${project.repoName}/envvar/CFA_SECRET`);
+  }
+  await client.post(
+    `/project/gh/${project.repoOwner}/${project.repoName}/envvar`,
+    {
+      body: {
+        name: 'CFA_SECRET',
+        value: project.secret,
+      },
+    },
+  );
+
+  if (existing.data.items.find(item => item.name === 'CFA_PROJECT_ID')) {
+    await client.delete(`/project/gh/${project.repoOwner}/${project.repoName}/envvar/CFA_PROJECT_ID`);
+  }
+  await client.post(
+    `/project/gh/${project.repoOwner}/${project.repoName}/envvar`,
+    {
+      body: {
+        name: 'CFA_PROJECT_ID',
+        value: project.id,
+      },
+    },
+  );
+}
+
 export function configRoutes() {
   const router = express();
 
@@ -41,7 +81,7 @@ export function configRoutes() {
         if (!project) return;
 
         const response = await axios.get(
-          `https://circleci.com/api/v1.1/project/github/${project.repoOwner}/${project.repoName}/checkout-key`,
+          `https://circleci.com/api/v2/project/gh/${project.repoOwner}/${project.repoName}/checkout-key`,
           {
             auth: {
               username: req.body.accessToken,
@@ -57,6 +97,8 @@ export function configRoutes() {
               'That token is not valid for the current project, or the repository is not configured on CircleCI',
           });
         }
+
+        await updateCircleEnvVars(project, req.body.accessToken);
 
         const newProject = await withTransaction(async t => {
           const config = await CircleCIRequesterConfig.create(

--- a/src/server/api/project/index.ts
+++ b/src/server/api/project/index.ts
@@ -6,7 +6,7 @@ import { Octokit, RestEndpointMethodTypes } from '@octokit/rest';
 import { createA } from '../../helpers/a';
 import { validate, hasAdminAccessToTargetRepo } from '../../helpers/_middleware';
 import { Project, withTransaction, OTPRequest } from '../../db/models';
-import { configRoutes } from './config';
+import { configRoutes, updateCircleEnvVars } from './config';
 import { sanitizeProject, generateNewSecret, getProjectFromIdAndCheckPermissions } from './_safe';
 
 const d = debug('cfa:server:api:auth');
@@ -159,6 +159,10 @@ export function projectRoutes() {
 
         project.secret = generateNewSecret(256);
         await project.save();
+
+        if (project.requester_circleCI) {
+          await updateCircleEnvVars(project, project.requester_circleCI.accessToken);
+        }
 
         res.json(sanitizeProject(project));
       },

--- a/src/server/api/repo/index.ts
+++ b/src/server/api/repo/index.ts
@@ -37,6 +37,7 @@ export function repoRoutes() {
         const allRepos: RestEndpointMethodTypes['repos']['listForAuthenticatedUser']['response']['data'] = await github.paginate(
           github.repos.listForAuthenticatedUser.endpoint.merge({
             per_page: 100,
+            visibility: 'all'
           }),
         );
 
@@ -83,9 +84,9 @@ export function repoRoutes() {
             requester_travisCI: !!p.requester_travisCI,
             responder_slack: p.responder_slack
               ? {
-                  team: p.responder_slack.teamName,
-                  channel: p.responder_slack.channelName,
-                }
+                team: p.responder_slack.teamName,
+                channel: p.responder_slack.channelName,
+              }
               : null,
           };
         }),

--- a/src/server/api/repo/index.ts
+++ b/src/server/api/repo/index.ts
@@ -37,7 +37,7 @@ export function repoRoutes() {
         const allRepos: RestEndpointMethodTypes['repos']['listForAuthenticatedUser']['response']['data'] = await github.paginate(
           github.repos.listForAuthenticatedUser.endpoint.merge({
             per_page: 100,
-            visibility: 'public'
+            visibility: 'public',
           }),
         );
 
@@ -84,9 +84,9 @@ export function repoRoutes() {
             requester_travisCI: !!p.requester_travisCI,
             responder_slack: p.responder_slack
               ? {
-                team: p.responder_slack.teamName,
-                channel: p.responder_slack.channelName,
-              }
+                  team: p.responder_slack.teamName,
+                  channel: p.responder_slack.channelName,
+                }
               : null,
           };
         }),

--- a/src/server/api/repo/index.ts
+++ b/src/server/api/repo/index.ts
@@ -37,7 +37,7 @@ export function repoRoutes() {
         const allRepos: RestEndpointMethodTypes['repos']['listForAuthenticatedUser']['response']['data'] = await github.paginate(
           github.repos.listForAuthenticatedUser.endpoint.merge({
             per_page: 100,
-            visibility: 'all'
+            visibility: 'public'
           }),
         );
 

--- a/src/server/api/request/__tests__/requester.spec.ts
+++ b/src/server/api/request/__tests__/requester.spec.ts
@@ -18,6 +18,8 @@ const makeMockRequester = () => ({
   validateProofForRequest: jest.fn(),
   isOTPRequestValidForRequester: jest.fn(),
   getRequestInformationToPassOn: jest.fn(),
+  getOpenIDConnectDiscoveryURL: jest.fn(),
+  doOpenIDConnectClaimsMatchProject: jest.fn(),
 });
 
 describe('requester endpoint creator', () => {

--- a/src/server/api/request/requester.ts
+++ b/src/server/api/request/requester.ts
@@ -94,7 +94,7 @@ export function createRequesterRoutes<R, M>(requester: Requester<R, M>) {
 
   router.post(`/:projectId/${requester.slug}/test`, (req, res) => res.json({ ok: true }));
 
-  router.get(
+  router.post(
     `/:projectId/${requester.slug}/credentials`,
     validate(
       {

--- a/src/server/api/request/requester.ts
+++ b/src/server/api/request/requester.ts
@@ -128,17 +128,17 @@ export function createRequesterRoutes<R, M>(requester: Requester<R, M>) {
         if (jwks.status !== 200)
           return res.status(422).json({ error: 'Project is not eligible for JWKS backed OIDC credential exchange' });
 
-        let claims = jwt.decode(req.body.token) as jwt.JwtPayload | null;
+        let claims = jwt.decode(req.body.token, { complete: true }) as jwt.Jwt | null;
         if (!claims)
           return res.status(422).json({ error: 'Invalid OIDC token provided' });
-        const key = jwks.data.keys.find(key => key.kid === claims!.headers.kid);
+        const key = jwks.data.keys.find(key => key.kid === claims!.header.kid);
 
         if (!key)
           return res.status(422).json({ error: 'Invalid kid found in the token provided' });
 
         const pem = jwkToPem(key);
         try {
-          claims = jwt.verify(req.body.token, pem) as jwt.JwtPayload | null;
+          claims = jwt.verify(req.body.token, pem, { complete: true }) as jwt.Jwt | null;
         } catch {
           return res.status(422).json({ error: 'Could not verify the provided token against the OIDC provider' });
         }
@@ -146,7 +146,7 @@ export function createRequesterRoutes<R, M>(requester: Requester<R, M>) {
         if (!claims)
           return res.status(422).json({ error: 'Invalid OIDC token provided' });
 
-        if (!(await requester.doOpenIDConnectClaimsMatchProject(claims, project, config))) {
+        if (!(await requester.doOpenIDConnectClaimsMatchProject(claims.payload as jwt.JwtPayload, project, config))) {
           return res.status(422).json({ error: 'Provided OIDC token does not match project' });
         }
 

--- a/src/server/db/models.ts
+++ b/src/server/db/models.ts
@@ -378,8 +378,8 @@ const create = async () => {
       ssl: process.env.NO_DB_SSL
         ? false
         : {
-          rejectUnauthorized: false,
-        },
+            rejectUnauthorized: false,
+          },
     },
   });
   await initializeInstance(sequelize);

--- a/src/server/db/models.ts
+++ b/src/server/db/models.ts
@@ -378,8 +378,8 @@ const create = async () => {
       ssl: process.env.NO_DB_SSL
         ? false
         : {
-            rejectUnauthorized: false,
-          },
+          rejectUnauthorized: false,
+        },
     },
   });
   await initializeInstance(sequelize);

--- a/src/server/requesters/CircleCIRequester.ts
+++ b/src/server/requesters/CircleCIRequester.ts
@@ -21,13 +21,10 @@ export const getAxiosForConfig = (config: CircleCIRequesterConfig) =>
     validateStatus: () => true,
   });
 
+// Unauthenticated
 export const getAxiosForConfigV2 = (config: CircleCIRequesterConfig) =>
   axios.create({
     baseURL: 'https://circleci.com/api/v2',
-    auth: {
-      username: config.accessToken,
-      password: '',
-    },
     validateStatus: () => true,
   });
 

--- a/src/server/requesters/CircleCIRequester.ts
+++ b/src/server/requesters/CircleCIRequester.ts
@@ -58,7 +58,11 @@ export class CircleCIRequester
     return `https://oidc.circleci.com/org/${orgId}`;
   }
 
-  async doOpenIDConnectClaimsMatchProject(claims: jwt.JwtPayload, project: Project, config: CircleCIRequesterConfig) {
+  async doOpenIDConnectClaimsMatchProject(
+    claims: jwt.JwtPayload,
+    project: Project,
+    config: CircleCIRequesterConfig,
+  ) {
     const projectResponse = await getAxiosForConfigV2(config).get(
       `/project/gh/${project.repoOwner}/${project.repoName}`,
     );

--- a/src/server/requesters/Requester.ts
+++ b/src/server/requesters/Requester.ts
@@ -1,16 +1,17 @@
 import { Request, Response } from 'express';
+import * as jwt from 'jsonwebtoken';
 
 import { Project, OTPRequest } from '../db/models';
 import { RequestInformation } from '../responders/Responder';
 
 export type AllowedState =
   | {
-      ok: true;
-    }
+    ok: true;
+  }
   | {
-      ok: false;
-      error: string;
-    };
+    ok: false;
+    error: string;
+  };
 
 export interface Requester<RequesterConfig, MetadataType> {
   /**
@@ -84,4 +85,14 @@ export interface Requester<RequesterConfig, MetadataType> {
   getRequestInformationToPassOn(
     request: OTPRequest<MetadataType, unknown>,
   ): Promise<RequestInformation>;
+  /**
+   * This returns the OIDC discovery URL for the given provider.
+   *
+   * For providers that don't support OIDC return null and no behavior will change.
+   */
+  getOpenIDConnectDiscoveryURL(project: Project, config: RequesterConfig): Promise<string | null>;
+  /**
+   * This should validate the given JWT claims against the expected project.
+   */
+  doOpenIDConnectClaimsMatchProject(claims: jwt.JwtPayload, project: Project, config: RequesterConfig): Promise<boolean>;
 }

--- a/src/server/requesters/Requester.ts
+++ b/src/server/requesters/Requester.ts
@@ -6,12 +6,12 @@ import { RequestInformation } from '../responders/Responder';
 
 export type AllowedState =
   | {
-    ok: true;
-  }
+      ok: true;
+    }
   | {
-    ok: false;
-    error: string;
-  };
+      ok: false;
+      error: string;
+    };
 
 export interface Requester<RequesterConfig, MetadataType> {
   /**
@@ -94,5 +94,9 @@ export interface Requester<RequesterConfig, MetadataType> {
   /**
    * This should validate the given JWT claims against the expected project.
    */
-  doOpenIDConnectClaimsMatchProject(claims: jwt.JwtPayload, project: Project, config: RequesterConfig): Promise<boolean>;
+  doOpenIDConnectClaimsMatchProject(
+    claims: jwt.JwtPayload,
+    project: Project,
+    config: RequesterConfig,
+  ): Promise<boolean>;
 }

--- a/src/server/requesters/TravisCIRequester.ts
+++ b/src/server/requesters/TravisCIRequester.ts
@@ -1,6 +1,7 @@
 import axios from 'axios';
 import { Request, Response } from 'express';
 import * as Joi from 'joi';
+import * as jwt from 'jsonwebtoken';
 
 import { Requester, AllowedState } from './Requester';
 import { Project, OTPRequest, TravisCIRequesterConfig } from '../db/models';
@@ -75,6 +76,14 @@ export class TravisCIRequester
 
   getConfigForProject(project: Project) {
     return project.requester_travisCI || null;
+  }
+
+  async getOpenIDConnectDiscoveryURL(_project: Project, _config: TravisCIRequesterConfig) {
+    return null;
+  }
+
+  async doOpenIDConnectClaimsMatchProject(_claims: jwt.JwtPayload, _project: Project, _config: TravisCIRequesterConfig) {
+    return false;
   }
 
   async metadataForInitialRequest(

--- a/src/server/requesters/TravisCIRequester.ts
+++ b/src/server/requesters/TravisCIRequester.ts
@@ -82,7 +82,11 @@ export class TravisCIRequester
     return null;
   }
 
-  async doOpenIDConnectClaimsMatchProject(_claims: jwt.JwtPayload, _project: Project, _config: TravisCIRequesterConfig) {
+  async doOpenIDConnectClaimsMatchProject(
+    _claims: jwt.JwtPayload,
+    _project: Project,
+    _config: TravisCIRequesterConfig,
+  ) {
     return false;
   }
 

--- a/src/server/responders/SlackResponder.ts
+++ b/src/server/responders/SlackResponder.ts
@@ -186,38 +186,41 @@ bolt.command(
 /**
  * Handle the "Open Dialog" button
  */
-bolt.action({
-  type: 'interactive_message',
-  callback_id: /^otp-token\//g,
-}, async ({ context, action, ack, body, next }) => {
-  if (
-    action &&
-    action.type === 'button' &&
-    action.value === 'open-otp-dialog' &&
-    'trigger_id' in body &&
-    'name' in action
-  ) {
-    await ack();
+bolt.action(
+  {
+    type: 'interactive_message',
+    callback_id: /^otp-token\//g,
+  },
+  async ({ context, action, ack, body, next }) => {
+    if (
+      action &&
+      action.type === 'button' &&
+      action.value === 'open-otp-dialog' &&
+      'trigger_id' in body &&
+      'name' in action
+    ) {
+      await ack();
 
-    await bolt.client.dialog.open({
-      token: context.botToken,
-      trigger_id: body.trigger_id,
-      dialog: {
-        title: 'Enter 2FA OTP',
-        callback_id: `otp:${action.name}`,
-        elements: [
-          {
-            type: 'text',
-            label: 'OTP',
-            name: 'otp',
-          },
-        ],
-      },
-    });
-  } else {
-    await next();
-  }
-});
+      await bolt.client.dialog.open({
+        token: context.botToken,
+        trigger_id: body.trigger_id,
+        dialog: {
+          title: 'Enter 2FA OTP',
+          callback_id: `otp:${action.name}`,
+          elements: [
+            {
+              type: 'text',
+              label: 'OTP',
+              name: 'otp',
+            },
+          ],
+        },
+      });
+    } else {
+      await next();
+    }
+  },
+);
 
 /**
  * Handle dialog submission

--- a/src/server/responders/SlackResponder.ts
+++ b/src/server/responders/SlackResponder.ts
@@ -186,7 +186,10 @@ bolt.command(
 /**
  * Handle the "Open Dialog" button
  */
-bolt.action(/^otp-token\//g, async ({ context, action, ack, body, next }) => {
+bolt.action({
+  type: 'interactive_message',
+  callback_id: /^otp-token\//g,
+}, async ({ context, action, ack, body, next }) => {
   if (
     action &&
     action.type === 'button' &&

--- a/yarn.lock
+++ b/yarn.lock
@@ -688,6 +688,57 @@
     mkdirp "^1.0.4"
     rimraf "^3.0.2"
 
+"@octokit/auth-app@^4.0.7":
+  version "4.0.7"
+  resolved "https://registry.yarnpkg.com/@octokit/auth-app/-/auth-app-4.0.7.tgz#417c327e6a7ada1e6e9651db681146f8c12728e3"
+  integrity sha512-hjjVCoI/+1oLminVHJPPexguYb9FP4Q60hEHExgy1uAKMMJ5Zf8iJIeRJlIIqneTb4vt7NvUTEj4YDxBLZ1FLg==
+  dependencies:
+    "@octokit/auth-oauth-app" "^5.0.0"
+    "@octokit/auth-oauth-user" "^2.0.0"
+    "@octokit/request" "^6.0.0"
+    "@octokit/request-error" "^3.0.0"
+    "@octokit/types" "^8.0.0"
+    "@types/lru-cache" "^5.1.0"
+    deprecation "^2.3.1"
+    lru-cache "^6.0.0"
+    universal-github-app-jwt "^1.0.1"
+    universal-user-agent "^6.0.0"
+
+"@octokit/auth-oauth-app@^5.0.0":
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/@octokit/auth-oauth-app/-/auth-oauth-app-5.0.4.tgz#ebd9a38f75381093d1a5e08e05b70b94f0918277"
+  integrity sha512-zlWuii5hAN50vsV6SJC+uIJ7SMhyWjQMEmKJQxkmNDlieE9LjnkZnbOjqRsfcG7VO7WTl4K8ccpo/3A7Kdpmrw==
+  dependencies:
+    "@octokit/auth-oauth-device" "^4.0.0"
+    "@octokit/auth-oauth-user" "^2.0.0"
+    "@octokit/request" "^6.0.0"
+    "@octokit/types" "^8.0.0"
+    "@types/btoa-lite" "^1.0.0"
+    btoa-lite "^1.0.0"
+    universal-user-agent "^6.0.0"
+
+"@octokit/auth-oauth-device@^4.0.0":
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/@octokit/auth-oauth-device/-/auth-oauth-device-4.0.3.tgz#00ce77233517e0d7d39e42a02652f64337d9df81"
+  integrity sha512-KPTx5nMntKjNZzzltO3X4T68v22rd7Cp/TcLJXQE2U8aXPcZ9LFuww9q9Q5WUNSu3jwi3lRwzfkPguRfz1R8Vg==
+  dependencies:
+    "@octokit/oauth-methods" "^2.0.0"
+    "@octokit/request" "^6.0.0"
+    "@octokit/types" "^8.0.0"
+    universal-user-agent "^6.0.0"
+
+"@octokit/auth-oauth-user@^2.0.0":
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/@octokit/auth-oauth-user/-/auth-oauth-user-2.0.4.tgz#88f060ec678d7d493695af8d827e115dd064e212"
+  integrity sha512-HrbDzTPqz6GcGSOUkR+wSeF3vEqsb9NMsmPja/qqqdiGmlk/Czkxctc3KeWYogHonp62Ml4kjz2VxKawrFsadQ==
+  dependencies:
+    "@octokit/auth-oauth-device" "^4.0.0"
+    "@octokit/oauth-methods" "^2.0.0"
+    "@octokit/request" "^6.0.0"
+    "@octokit/types" "^8.0.0"
+    btoa-lite "^1.0.0"
+    universal-user-agent "^6.0.0"
+
 "@octokit/auth-token@^3.0.0":
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/@octokit/auth-token/-/auth-token-3.0.2.tgz#a0fc8de149fd15876e1ac78f6525c1c5ab48435f"
@@ -725,6 +776,22 @@
     "@octokit/request" "^6.0.0"
     "@octokit/types" "^8.0.0"
     universal-user-agent "^6.0.0"
+
+"@octokit/oauth-authorization-url@^5.0.0":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@octokit/oauth-authorization-url/-/oauth-authorization-url-5.0.0.tgz#029626ce87f3b31addb98cd0d2355c2381a1c5a1"
+  integrity sha512-y1WhN+ERDZTh0qZ4SR+zotgsQUE1ysKnvBt1hvDRB2WRzYtVKQjn97HEPzoehh66Fj9LwNdlZh+p6TJatT0zzg==
+
+"@octokit/oauth-methods@^2.0.0":
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/@octokit/oauth-methods/-/oauth-methods-2.0.4.tgz#6abd9593ca7f91fe5068375a363bd70abd5516dc"
+  integrity sha512-RDSa6XL+5waUVrYSmOlYROtPq0+cfwppP4VaQY/iIei3xlFb0expH6YNsxNrZktcLhJWSpm9uzeom+dQrXlS3A==
+  dependencies:
+    "@octokit/oauth-authorization-url" "^5.0.0"
+    "@octokit/request" "^6.0.0"
+    "@octokit/request-error" "^3.0.0"
+    "@octokit/types" "^8.0.0"
+    btoa-lite "^1.0.0"
 
 "@octokit/openapi-types@^14.0.0":
   version "14.0.0"
@@ -1044,6 +1111,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/btoa-lite@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@types/btoa-lite/-/btoa-lite-1.0.0.tgz#e190a5a548e0b348adb0df9ac7fa5f1151c7cca4"
+  integrity sha512-wJsiX1tosQ+J5+bY5LrSahHxr2wT+uME5UDwdN1kg4frt40euqA+wzECkmq4t5QbveHiJepfdThgQrPw6KiSlg==
+
 "@types/cheerio@*", "@types/cheerio@^0.22.22":
   version "0.22.31"
   resolved "https://registry.yarnpkg.com/@types/cheerio/-/cheerio-0.22.31.tgz#b8538100653d6bb1b08a1e46dec75b4f2a5d5eb6"
@@ -1261,12 +1333,22 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.11.tgz#d421b6c527a3037f7c84433fd2c4229e016863d3"
   integrity sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==
 
-"@types/jsonwebtoken@^8.3.7":
+"@types/jsonwebtoken@^8.3.3", "@types/jsonwebtoken@^8.3.7":
   version "8.5.9"
   resolved "https://registry.yarnpkg.com/@types/jsonwebtoken/-/jsonwebtoken-8.5.9.tgz#2c064ecb0b3128d837d2764aa0b117b0ff6e4586"
   integrity sha512-272FMnFGzAVMGtu9tkr29hRL6bZj4Zs1KZNeHLnKqAvp06tAIcarTMwOh8/8bz4FmKRcMxZhZNeUAQsNLoiPhg==
   dependencies:
     "@types/node" "*"
+
+"@types/jwk-to-pem@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@types/jwk-to-pem/-/jwk-to-pem-2.0.1.tgz#ba6949f447e02cb7bebf101551e3a4dea5f4fde4"
+  integrity sha512-QXmRPhR/LPzvXBHTPfG2BBfMTkNLUD7NyRcPft8m5xFCeANa1BZyLgT0Gw+OxdWx6i1WCpT27EqyggP4UUHMrA==
+
+"@types/lru-cache@^5.1.0":
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/@types/lru-cache/-/lru-cache-5.1.1.tgz#c48c2e27b65d2a153b19bfc1a317e30872e01eef"
+  integrity sha512-ssE3Vlrys7sdIzs5LOxCzTVMsU7i9oa/IaW92wF32JFb3CVczqOkru2xspuKczHEbG3nvmPY7IFqVmGGHdNbYw==
 
 "@types/mime@*":
   version "3.0.1"
@@ -1960,6 +2042,16 @@ asap@^2.0.0, asap@~2.0.3:
   resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
   integrity sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==
 
+asn1.js@^5.3.0:
+  version "5.4.1"
+  resolved "https://registry.yarnpkg.com/asn1.js/-/asn1.js-5.4.1.tgz#11a980b84ebb91781ce35b0fdc2ee294e3783f07"
+  integrity sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==
+  dependencies:
+    bn.js "^4.0.0"
+    inherits "^2.0.1"
+    minimalistic-assert "^1.0.0"
+    safer-buffer "^2.1.0"
+
 asn1@~0.2.3:
   version "0.2.4"
   resolved "https://registry.yarnpkg.com/asn1/-/asn1-0.2.4.tgz#8d2475dfab553bb33e77b54e59e880bb8ce23136"
@@ -2128,6 +2220,11 @@ bluebird@^3.5.0:
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
   integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
 
+bn.js@^4.0.0, bn.js@^4.11.9:
+  version "4.12.0"
+  resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.12.0.tgz#775b3f278efbb9718eec7361f483fb36fbbfea88"
+  integrity sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==
+
 body-parser@1.20.1:
   version "1.20.1"
   resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.20.1.tgz#b1812a8912c195cd371a3ee5e66faa2338a5c668"
@@ -2181,6 +2278,11 @@ braces@^3.0.2, braces@~3.0.2:
   dependencies:
     fill-range "^7.0.1"
 
+brorand@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/brorand/-/brorand-1.1.0.tgz#12c25efe40a45e3c323eb8675a0a0ce57b22371f"
+  integrity sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==
+
 browserslist@^4.0.0, browserslist@^4.14.5, browserslist@^4.16.6, browserslist@^4.20.3, browserslist@^4.21.3, browserslist@^4.21.4:
   version "4.21.4"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.21.4.tgz#e7496bbc67b9e39dd0f98565feccdcb0d4ff6987"
@@ -2204,6 +2306,11 @@ bser@^2.0.0:
   integrity sha1-mseNPtXZFYBP2HrLFYvHlxR6Fxk=
   dependencies:
     node-int64 "^0.4.0"
+
+btoa-lite@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/btoa-lite/-/btoa-lite-1.0.0.tgz#337766da15801210fdd956c22e9c6891ab9d0337"
+  integrity sha512-gvW7InbIyF8AicrqWoptdW08pUxuhq8BEgowNajy9RhiE86fmGAGl+bLKo6oB8QP0CkqHLowfN0oJdKC/J6LbA==
 
 buffer-equal-constant-time@1.0.1:
   version "1.0.1"
@@ -3168,6 +3275,19 @@ electron-to-chromium@^1.4.251:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.283.tgz#d4f263f5df402fd799c0a06255d580dcf8aa9a8e"
   integrity sha512-g6RQ9zCOV+U5QVHW9OpFR7rdk/V7xfopNXnyAamdpFgCHgZ1sjI8VuR1+zG2YG/TZk+tQ8mpNkug4P8FU0fuOA==
 
+elliptic@^6.5.4:
+  version "6.5.4"
+  resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.4.tgz#da37cebd31e79a1367e941b592ed1fbebd58abbb"
+  integrity sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==
+  dependencies:
+    bn.js "^4.11.9"
+    brorand "^1.1.0"
+    hash.js "^1.0.0"
+    hmac-drbg "^1.0.1"
+    inherits "^2.0.4"
+    minimalistic-assert "^1.0.1"
+    minimalistic-crypto-utils "^1.0.1"
+
 emittery@^0.10.2:
   version "0.10.2"
   resolved "https://registry.yarnpkg.com/emittery/-/emittery-0.10.2.tgz#902eec8aedb8c41938c46e9385e9db7e03182933"
@@ -4079,6 +4199,14 @@ has@^1.0.3:
   dependencies:
     function-bind "^1.1.1"
 
+hash.js@^1.0.0, hash.js@^1.0.3:
+  version "1.1.7"
+  resolved "https://registry.yarnpkg.com/hash.js/-/hash.js-1.1.7.tgz#0babca538e8d4ee4a0f8988d68866537a003cf42"
+  integrity sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==
+  dependencies:
+    inherits "^2.0.3"
+    minimalistic-assert "^1.0.1"
+
 he@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
@@ -4100,6 +4228,15 @@ history@^4.9.0:
     tiny-invariant "^1.0.2"
     tiny-warning "^1.0.0"
     value-equal "^1.0.1"
+
+hmac-drbg@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/hmac-drbg/-/hmac-drbg-1.0.1.tgz#d2745701025a6c775a6c545793ed502fc0c649a1"
+  integrity sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==
+  dependencies:
+    hash.js "^1.0.3"
+    minimalistic-assert "^1.0.0"
+    minimalistic-crypto-utils "^1.0.1"
 
 hoek@6.x.x:
   version "6.1.3"
@@ -4392,7 +4529,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@2.0.4, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.3:
+inherits@2, inherits@2.0.4, inherits@^2.0.1, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.3:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -5206,6 +5343,11 @@ joi@^14.3.1:
     isemail "3.x.x"
     topo "3.x.x"
 
+jose@^4.1.4:
+  version "4.10.0"
+  resolved "https://registry.yarnpkg.com/jose/-/jose-4.10.0.tgz#2e0b7bcc80dd0775f8a4588e55beb9460c37d60a"
+  integrity sha512-KEhB/eLGLomWGPTb+/RNbYsTjIyx03JmbqAyIyiXBuNSa7CmNrJd5ysFhblayzs/e/vbOPMUaLnjHUMhGp4yLw==
+
 js-base64@^2.4.9:
   version "2.6.4"
   resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.6.4.tgz#f4e686c5de1ea1f867dbcad3d46d969428df98c4"
@@ -5343,6 +5485,15 @@ jwa@^1.4.1:
   dependencies:
     buffer-equal-constant-time "1.0.1"
     ecdsa-sig-formatter "1.0.11"
+    safe-buffer "^5.0.1"
+
+jwk-to-pem@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/jwk-to-pem/-/jwk-to-pem-2.0.5.tgz#151310bcfbcf731adc5ad9f379cbc8b395742906"
+  integrity sha512-L90jwellhO8jRKYwbssU9ifaMVqajzj3fpRjDKcsDzrslU9syRbFqfkXtT4B89HYAap+xsxNcxgBSB09ig+a7A==
+  dependencies:
+    asn1.js "^5.3.0"
+    elliptic "^6.5.4"
     safe-buffer "^5.0.1"
 
 jws@^3.2.2:
@@ -5732,10 +5883,15 @@ mini-css-extract-plugin@^2.6.1:
   dependencies:
     schema-utils "^4.0.0"
 
-minimalistic-assert@^1.0.0:
+minimalistic-assert@^1.0.0, minimalistic-assert@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz#2e194de044626d4a10e7f7fbc00ce73e83e4d5c7"
   integrity sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==
+
+minimalistic-crypto-utils@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz#f6c00c1c0b082246e5c4d99dfb8c7c083b2b582a"
+  integrity sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==
 
 minimatch@^3.0.4, minimatch@^3.1.1, minimatch@^3.1.2:
   version "3.1.2"
@@ -6136,6 +6292,11 @@ object-assign@^4.1.0, object-assign@^4.1.1:
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==
 
+object-hash@^2.0.1:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/object-hash/-/object-hash-2.2.0.tgz#5ad518581eefc443bd763472b8ff2e9c2c0d54a5"
+  integrity sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==
+
 object-inspect@^1.12.2, object-inspect@^1.7.0, object-inspect@^1.9.0:
   version "1.12.2"
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.12.2.tgz#c0641f26394532f28ab8d796ab954e43c009a8ea"
@@ -6196,6 +6357,11 @@ obuf@^1.0.0, obuf@^1.1.2:
   resolved "https://registry.yarnpkg.com/obuf/-/obuf-1.1.2.tgz#09bea3343d41859ebd446292d11c9d4db619084e"
   integrity sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==
 
+oidc-token-hash@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/oidc-token-hash/-/oidc-token-hash-5.0.1.tgz#ae6beec3ec20f0fd885e5400d175191d6e2f10c6"
+  integrity sha512-EvoOtz6FIEBzE+9q253HsLCVRiK/0doEJ2HCvvqMQb3dHZrP3WlJKYtJ55CRTw4jmYomzH4wkPuCj/I3ZvpKxQ==
+
 on-finished@2.4.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/on-finished/-/on-finished-2.4.1.tgz#58c8c44116e54845ad57f14ab10b03533184ac3f"
@@ -6250,6 +6416,16 @@ opener@^1.5.2:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/opener/-/opener-1.5.2.tgz#5d37e1f35077b9dcac4301372271afdeb2a13598"
   integrity sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==
+
+openid-client@^5.1.10:
+  version "5.1.10"
+  resolved "https://registry.yarnpkg.com/openid-client/-/openid-client-5.1.10.tgz#add6044878b9be75ffdd09abfcaae6feff376b1f"
+  integrity sha512-KYAtkxTuUwTvjAmH0QMFFP3i9l0+XhP2/blct6Q9kn+DUJ/lu8/g/bI8ghSgxz9dJLm/9cpB/1uLVGTcGGY0hw==
+  dependencies:
+    jose "^4.1.4"
+    lru-cache "^6.0.0"
+    object-hash "^2.0.1"
+    oidc-token-hash "^5.0.1"
 
 optimize-css-assets-webpack-plugin@^6.0.1:
   version "6.0.1"
@@ -8506,6 +8682,14 @@ unique-slug@^2.0.0:
   integrity sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==
   dependencies:
     imurmurhash "^0.1.4"
+
+universal-github-app-jwt@^1.0.1:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/universal-github-app-jwt/-/universal-github-app-jwt-1.1.0.tgz#0abaa876101cdf1d3e4c546be2768841c0c1b514"
+  integrity sha512-3b+ocAjjz4JTyqaOT+NNBd5BtTuvJTxWElIoeHSVelUV9J3Jp7avmQTdLKCaoqi/5Ox2o/q+VK19TJ233rVXVQ==
+  dependencies:
+    "@types/jsonwebtoken" "^8.3.3"
+    jsonwebtoken "^8.5.1"
 
 universal-user-agent@^6.0.0:
   version "6.0.0"


### PR DESCRIPTION
This PR does a few things to make setting up CFA dramatically easier.

* Upon configuring CircleCI requesters we now automatically set the `CFA_PROJECT_ID` and `CFA_SECRET` environment variables
* Resetting the project secret automatically updates the `CFA_SECRET` environment variable
* Exposes an endpoint that allows valid CircleCI OIDC tokens to request a GitHub App Installation token for just that project to use as a semantic release GITHUB_TOKEN

This means (at least for the electron org) the process of setting up CFA has been simplified to:
* Construct a valid CircleCI config (now including a reference to `@continuous-auth/circleci-oidc-github-auth`)
* Use the `cfa-release` context on the release job in your CircleCI config
* Set up the project on CFA

There will be a separate repository / doc outlining how to create _new_ npm packages for CFA to publish.