### PR TITLE
feat: support CircleCI builds for tags on default branch

### DIFF
--- a/src/server/helpers/auth.ts
+++ b/src/server/helpers/auth.ts
@@ -1,0 +1,32 @@
+import { createAppAuth } from '@octokit/auth-app';
+import { Octokit } from '@octokit/rest';
+
+import { Project } from '../db/models';
+
+export const getGitHubAppInstallationToken = async (project: Project) => {
+  const appCredentials = {
+    appId: process.env.GITHUB_APP_ID!,
+    privateKey: process.env.GITHUB_PRIVATE_KEY!,
+  };
+
+  const appOctokit = new Octokit({
+    authStrategy: createAppAuth,
+    auth: {
+      ...appCredentials,
+    },
+  });
+
+  const installation = await appOctokit.apps.getRepoInstallation({
+    owner: project.repoOwner,
+    repo: project.repoName,
+  });
+
+  const authOptions = {
+    type: <const>'installation',
+    ...appCredentials,
+    installationId: installation.data.id,
+    repositoryNames: [project.repoName],
+  };
+  const { token } = await createAppAuth(authOptions)(authOptions);
+  return token;
+};

--- a/src/server/requesters/CircleCIRequester.ts
+++ b/src/server/requesters/CircleCIRequester.ts
@@ -6,6 +6,7 @@ import * as jwt from 'jsonwebtoken';
 
 import { Requester, AllowedState } from './Requester';
 import { Project, CircleCIRequesterConfig, OTPRequest } from '../db/models';
+import { getGitHubAppInstallationToken } from '../helpers/auth';
 import { RequestInformation } from '../responders/Responder';
 
 export type CircleCIOTPRequestMetadata = {
@@ -112,8 +113,8 @@ export class CircleCIRequester
 
     // Must be on the default branch
     if (build.vcs_tag) {
-      // TODO - What auth to use for Octokit?
-      const github = new Octokit({});
+      const token = await getGitHubAppInstallationToken(project);
+      const github = new Octokit({ auth: token });
       const tag = await github.git.getRef({
         owner: project.repoOwner,
         repo: project.repoName,


### PR DESCRIPTION
Motivating use case is for releases on `electron/mksnapshot` where the current implementation cuts the tag first and then does the CFA release on the tag.