### PR TITLE
docs: fix status badge in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CFA: Continuous Factor Authentication
 
-![GitHub Workflow Status](https://img.shields.io/github/workflow/status/continuousauth/web/CI?label=CI&logo=github&style=for-the-badge)
+[![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/continuousauth/web/ci.yaml?branch=main&label=CI&logo=github&style=for-the-badge)](https://github.com/continuousauth/web/actions/workflows/ci.yaml)
 
 This service is responsible for safely requesting and delivering a 2FA token to an arbitrary CI job. Typically though a tool like `semantic-release`.
 


### PR DESCRIPTION
The URL for the badge changed and needs to be updated. Also links it to the workflow for convenience.