### PR TITLE
fix: validate GHA buildURL correctly

### DIFF
--- a/src/server/requesters/GitHubActionsRequester.ts
+++ b/src/server/requesters/GitHubActionsRequester.ts
@@ -21,7 +21,7 @@ const validateMetadataObject = (object: any) => {
     oidcToken: Joi.string().min(1).required(),
     buildUrl: Joi.string()
       .uri({
-        scheme: 'https:',
+        scheme: 'https',
       })
       .required(),
   });


### PR DESCRIPTION
From the Joi docs (emphasis mine):

> `scheme` - Specifies one or more acceptable Schemes, **should only include the scheme name**. Can be an Array or String (strings are automatically escaped for use in a Regular Expression).

Tested locally to confirm valid HTTPS URLs were failing validation under `https:`.

cc @MarshallOfSound 