### PR TITLE
fix: validate payload not jwt container

### DIFF
--- a/src/server/requesters/GitHubActionsRequester.ts
+++ b/src/server/requesters/GitHubActionsRequester.ts
@@ -210,7 +210,10 @@ export class GitHubActionsRequester
       };
     }
 
-    const claimsEvaluation = await this.doOpenIDConnectClaimsMatchProjectInternal(claims, project);
+    const claimsEvaluation = await this.doOpenIDConnectClaimsMatchProjectInternal(
+      claims.payload as jwt.JwtPayload,
+      project,
+    );
     if (!claimsEvaluation.ok) {
       return {
         ok: false,


### PR DESCRIPTION
Typescript didn't yell because these eventually both end up at `Record<string, string>` which are compatible 🙃 