### PR TITLE
chore: temporarily allow node-abi releases from `3-x-y` branch

### DIFF
--- a/src/server/requesters/GitHubActionsRequester.ts
+++ b/src/server/requesters/GitHubActionsRequester.ts
@@ -105,6 +105,12 @@ export class GitHubActionsRequester
           error: 'GitHub Actions build is for a tag not on the default branch',
         };
       }
+    } else if (
+      claims.repository_owner === 'electron' &&
+      claims.repository === 'electron/node-abi' &&
+      claims.ref === 'refs/heads/3-x-y'
+    ) {
+      // Temporary hack to allow the 3-x-y branch to be used for releases on the node-abi repo
     } else if (claims.ref !== `refs/heads/${project.defaultBranch}`) {
       return {
         ok: false,


### PR DESCRIPTION
We're trying to give `node-abi` one last 3.x release so we need to temporarily allow a non-default branch (`3-x-y`) for the release job.