### PR TITLE
chore: revert node-abi 3-x-y exception for CFA

### DIFF
--- a/src/server/requesters/GitHubActionsRequester.ts
+++ b/src/server/requesters/GitHubActionsRequester.ts
@@ -105,12 +105,6 @@ export class GitHubActionsRequester
           error: 'GitHub Actions build is for a tag not on the default branch',
         };
       }
-    } else if (
-      claims.repository_owner === 'electron' &&
-      claims.repository === 'electron/node-abi' &&
-      claims.ref === 'refs/heads/3-x-y'
-    ) {
-      // Temporary hack to allow the 3-x-y branch to be used for releases on the node-abi repo
     } else if (claims.ref !== `refs/heads/${project.defaultBranch}`) {
       return {
         ok: false,


### PR DESCRIPTION
Follow-up to #91

This PR reverts the exception made for node-abi's 3-x-y release. Please merge after the 3-x-y release has been completed.